### PR TITLE
Fix ports overlap and `/etc/hosts` config

### DIFF
--- a/roles/sigstore_scaffolding/templates/configs/etc-hosts.j2
+++ b/roles/sigstore_scaffolding/templates/configs/etc-hosts.j2
@@ -1,3 +1,3 @@
-{% for item in ['keycloak','fulcio','tuf'] %}
+{% for item in ['keycloak','fulcio','tuf', 'rekor'] %}
 {{ hostvars[inventory_hostname].ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }} {{ item }}.{{ base_hostname }}
 {% endfor %}

--- a/roles/sigstore_scaffolding/templates/manifests/fulcio/fulcio-server.yaml
+++ b/roles/sigstore_scaffolding/templates/manifests/fulcio/fulcio-server.yaml
@@ -39,7 +39,7 @@ spec:
           protocol: TCP
         - containerPort: 5554
           protocol: TCP
-        - containerPort: 2112
+        - containerPort: 2113
           protocol: TCP
       resources: {}
       terminationMessagePath: /dev/termination-log

--- a/roles/sigstore_scaffolding/templates/manifests/trillian/trillian-logsigner.yaml
+++ b/roles/sigstore_scaffolding/templates/manifests/trillian/trillian-logsigner.yaml
@@ -44,7 +44,7 @@ spec:
       imagePullPolicy: IfNotPresent
       name: trillian-trillian-logsigner
       ports:
-        - containerPort: 8091
+        - containerPort: 8191
           protocol: TCP
       resources: {}
       terminationMessagePath: /dev/termination-log

--- a/roles/sigstore_scaffolding/templates/manifests/tuf/tuf.yaml
+++ b/roles/sigstore_scaffolding/templates/manifests/tuf/tuf.yaml
@@ -17,7 +17,7 @@ spec:
       imagePullPolicy: IfNotPresent
       name: tuf
       ports:
-        - containerPort: 8080
+        - containerPort: 8082
           protocol: TCP
       env:
         - name: NAMESPACE


### PR DESCRIPTION
- Fix ports overlap for Trillian, Rekor and Tuf preventing containers to run
- Add Rekor to `/etc/hosts` config to fix the service being unreachable