### PR TITLE
Fix Keycloak valid redirect URIs

### DIFF
--- a/roles/sigstore_scaffolding/defaults/main.yml
+++ b/roles/sigstore_scaffolding/defaults/main.yml
@@ -109,7 +109,7 @@ keycloak_auth_endpoint: ""
 
 keycloak_sigstore_client: sigstore
 keycloak_sigstore_client_redirect_uris:
-  - "http://localhost/auth/callback"
+  - "*"
 
 keycloak_sigstore_users:
  - username: jdoe


### PR DESCRIPTION
Fixes #11 

Setting `keycloak_sigstore_client_redirect_uris` to `*` fixed the issue for now, but this value should probably be more precise. Feel free to propose a better alternative if possible.