### PR TITLE
Revert "Fix missing quotes around trillian_tree_id variable in ctlog config template (#13)"

### DIFF
--- a/roles/sigstore_scaffolding/templates/configs/ctlog-config.j2
+++ b/roles/sigstore_scaffolding/templates/configs/ctlog-config.j2
@@ -1,2 +1,2 @@
 backends:{backend:{name:"trillian"  backend_spec:"trillian-logserver:8091"}}  
-log_configs:{config:{log_id:"{{ trillian_tree_id }}"  prefix:"{{ ct_logprefix }}"  roots_pem_file:"/ctfe-keys/fulcio-0"  private_key:{[type.googleapis.com/keyspb.PEMKeyFile]:{path:"/ctfe-keys/private"  password:"{{ ctlog_ca_passphrase }}"}}  ext_key_usages:"CodeSigning"  log_backend_name:"trillian"}}
+log_configs:{config:{log_id:{{ trillian_tree_id }}  prefix:"{{ ct_logprefix }}"  roots_pem_file:"/ctfe-keys/fulcio-0"  private_key:{[type.googleapis.com/keyspb.PEMKeyFile]:{path:"/ctfe-keys/private"  password:"{{ ctlog_ca_passphrase }}"}}  ext_key_usages:"CodeSigning"  log_backend_name:"trillian"}}


### PR DESCRIPTION
This reverts commit 1d1a3517ff1f6d3ae630402d3ff75eeba22bcb6d.

Sorry about the spam. It seemed at first like adding quotes fixed my issue, but it was due to another change.
Adding quotes prevented the config file from being parsed properly.


